### PR TITLE
Prevent installation of VanillaPlus

### DIFF
--- a/VTOL_2.0.0/Pages/Page_Thunderstore.xaml.cs
+++ b/VTOL_2.0.0/Pages/Page_Thunderstore.xaml.cs
@@ -4456,6 +4456,16 @@ int millisecondsDelay = 300)
                 }
                 Console.WriteLine(Button.Tag.ToString());
 
+                if (name.Contains("VanillaPlus"))
+                {
+                    Main.Snackbar.Message = "VanillaPlus cannot be installed through VTOL";
+                    Main.Snackbar.Title = VTOL.Resources.Languages.Language.INFO;
+                    Main.Snackbar.Appearance = Wpf.Ui.Common.ControlAppearance.Info;
+                    Main.Snackbar.Show();
+
+                    return;
+                }
+
                 DispatchIfNecessary(async () =>
                 {
                     if (parts[0].Contains("http") || parts[0].Contains("https"))


### PR DESCRIPTION
similar to https://github.com/0neGal/viper/pull/241

essentially, VanillaPlus has a unique installation process and is intended to be used with existing client side mods for improved Vanilla compatibility.

a common miss-step by end-users is to install it through Mod Managers, this PR adds a check and prevents that.

I've through about multiple ways to do this, but I am not too confident in my use of Blend and I don't know if there is some kind of tool to maintain Localisations, so I just hardcoded it (Like its done in other places)

An alternative would be to remove the install button completely